### PR TITLE
Fix Folia/CanvasMC compatibility — use native teleportAsync and getChunkAtAsync

### DIFF
--- a/src/main/java/eu/kotori/justRTP/handlers/PlayerListener.java
+++ b/src/main/java/eu/kotori/justRTP/handlers/PlayerListener.java
@@ -156,7 +156,7 @@ public class PlayerListener implements Listener {
                                                     return;
                                                 }
 
-                                                PaperLib.teleportAsync(player, targetLocation).thenAccept(success -> {
+                                                player.teleportAsync(targetLocation).thenAccept(success -> {
                                                     if (success && player.isOnline()) {
                                                         plugin.getRTPLogger().debug("JOIN",
                                                                 "Successfully teleported " + player.getName()

--- a/src/main/java/eu/kotori/justRTP/handlers/PlayerListener.java
+++ b/src/main/java/eu/kotori/justRTP/handlers/PlayerListener.java
@@ -3,7 +3,6 @@ package eu.kotori.justRTP.handlers;
 import eu.kotori.justRTP.JustRTP;
 import eu.kotori.justRTP.commands.RTPCommand;
 import eu.kotori.justRTP.utils.FoliaScheduler;
-import io.papermc.lib.PaperLib;
 import com.destroystokyo.paper.event.player.PlayerPostRespawnEvent;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -498,7 +497,7 @@ public class PlayerListener implements Listener {
                 int chunkX = centerChunkX + dx;
                 int chunkZ = centerChunkZ + dz;
 
-                chunkFutures[index++] = PaperLib.getChunkAtAsync(world, chunkX, chunkZ, false)
+                chunkFutures[index++] = world.getChunkAtAsync(chunkX, chunkZ, false)
                         .thenApply(chunk -> {
                             if (FoliaScheduler.isFolia() && chunk != null) {
                                 try {

--- a/src/main/java/eu/kotori/justRTP/handlers/RTPService.java
+++ b/src/main/java/eu/kotori/justRTP/handlers/RTPService.java
@@ -6,7 +6,6 @@ import eu.kotori.justRTP.handlers.hooks.HookManager;
 import eu.kotori.justRTP.managers.ConfigManager;
 import eu.kotori.justRTP.utils.FoliaScheduler;
 import eu.kotori.justRTP.utils.SafetyValidator;
-import io.papermc.lib.PaperLib;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
@@ -238,7 +237,7 @@ public class RTPService {
             for (int dz = -1; dz <= 1; dz++) {
                 int chunkX = centerChunkX + dx;
                 int chunkZ = centerChunkZ + dz;
-                PaperLib.getChunkAtAsync(world, chunkX, chunkZ, false);
+                world.getChunkAtAsync(chunkX, chunkZ, false);
             }
         }
     }
@@ -406,7 +405,7 @@ public class RTPService {
         int chunkX = x >> 4;
         int chunkZ = z >> 4;
 
-        return PaperLib.getChunkAtAsync(world, chunkX, chunkZ, generateChunks).thenCompose(chunk -> {
+        return world.getChunkAtAsync(chunkX, chunkZ, generateChunks).thenCompose(chunk -> {
             if (chunk == null) {
                 plugin.getRTPLogger().debug("CHUNK",
                         "Failed to load chunk at " + chunkX + ", " + chunkZ + " in " + world.getName()
@@ -429,7 +428,7 @@ public class RTPService {
                 List<CompletableFuture<Chunk>> neighborFutures = new ArrayList<>();
                 for (int dx = -1; dx <= 1; dx++) {
                     for (int dz = -1; dz <= 1; dz++) {
-                        neighborFutures.add(PaperLib.getChunkAtAsync(world, chunkX + dx, chunkZ + dz, true));
+                        neighborFutures.add(world.getChunkAtAsync(chunkX + dx, chunkZ + dz, true));
                     }
                 }
 

--- a/src/main/java/eu/kotori/justRTP/handlers/RTPService.java
+++ b/src/main/java/eu/kotori/justRTP/handlers/RTPService.java
@@ -182,7 +182,7 @@ public class RTPService {
             player.setVelocity(new org.bukkit.util.Vector(0, 0, 0));
             player.setFallDistance(0f);
 
-            PaperLib.teleportAsync(player, location).thenAccept(success -> {
+            player.teleportAsync(location).thenAccept(success -> {
                 if (success && player.isOnline()) {
                     plugin.getFoliaScheduler().runAtEntity(player, () -> {
                         if (!player.isOnline()) {

--- a/src/main/java/eu/kotori/justRTP/managers/NearClaimRTPManager.java
+++ b/src/main/java/eu/kotori/justRTP/managers/NearClaimRTPManager.java
@@ -2,7 +2,6 @@ package eu.kotori.justRTP.managers;
 
 import eu.kotori.justRTP.JustRTP;
 import eu.kotori.justRTP.utils.FormatUtils;
-import io.papermc.lib.PaperLib;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -166,7 +165,7 @@ public class NearClaimRTPManager {
         int chunkX = candidate.getBlockX() >> 4;
         int chunkZ = candidate.getBlockZ() >> 4;
         CompletableFuture<Optional<Location>> stepFuture = new CompletableFuture<>();
-        PaperLib.getChunkAtAsync(world, chunkX, chunkZ, true).thenAccept(chunk -> {
+        world.getChunkAtAsync(chunkX, chunkZ, true).thenAccept(chunk -> {
             this.plugin.getFoliaScheduler().runAtLocation(candidate, () -> {
                 try {
                     candidate.setY((double)(world.getHighestBlockYAt(candidate) + 1));

--- a/src/main/java/eu/kotori/justRTP/managers/PacketHologramManager.java
+++ b/src/main/java/eu/kotori/justRTP/managers/PacketHologramManager.java
@@ -147,7 +147,7 @@ public class PacketHologramManager implements Listener {
             return;
         }
 
-        io.papermc.lib.PaperLib.getChunkAtAsync(location).thenAccept(chunk -> {
+        location.getWorld().getChunkAtAsync(location).thenAccept(chunk -> {
             plugin.getFoliaScheduler().runAtLocation(location, () -> {
                 try {
                     removeHologram(zoneId);

--- a/src/main/java/eu/kotori/justRTP/managers/RTPZoneManager.java
+++ b/src/main/java/eu/kotori/justRTP/managers/RTPZoneManager.java
@@ -532,7 +532,7 @@ public class RTPZoneManager {
     }
 
     private CompletableFuture<Location> findSafeYAtLocationAsync(World world, int x, int z) {
-        return io.papermc.lib.PaperLib.getChunkAtAsync(world, x >> 4, z >> 4).thenApply(chunk -> {
+        return world.getChunkAtAsync(x >> 4, z >> 4).thenApply(chunk -> {
             if (chunk == null)
                 return null;
 

--- a/src/main/java/eu/kotori/justRTP/utils/SafetyValidator.java
+++ b/src/main/java/eu/kotori/justRTP/utils/SafetyValidator.java
@@ -1,7 +1,6 @@
 package eu.kotori.justRTP.utils;
 
 import eu.kotori.justRTP.JustRTP;
-import io.papermc.lib.PaperLib;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,7 +16,7 @@ public class SafetyValidator {
             return CompletableFuture.completedFuture(false);
         }
 
-        return PaperLib.getChunkAtAsync(location)
+        return location.getWorld().getChunkAtAsync(location)
                 .thenApply(chunk -> {
                     if (chunk == null)
                         return false;


### PR DESCRIPTION
## Summary
Two related Folia/CanvasMC compatibility fixes. Bundled PaperLib 1.0.8 falls back to **synchronous** implementations on CanvasMC 26.1.2 (a Folia fork), which Folia rejects with thread-check errors.

### 1. `teleportAsync` (commit 2b085f0)
Replaces two `PaperLib.teleportAsync(player, ...)` call sites with the native `Player.teleportAsync(...)` API. PaperLib's fallback calls a synchronous `entity.teleport()`, which Folia rejects with `UnsupportedOperationException: Must use teleportAsync while in region threading`.

### 2. `getChunkAtAsync` (commit b307175)
Replaces all eight `PaperLib.getChunkAtAsync(...)` call sites with the native `World#getChunkAtAsync(...)` API. PaperLib's `Environment.getChunkAtAsync` selects `AsyncChunksSync` on CanvasMC, which calls `world.getChunkAt()` on the calling thread — Folia rejects this with `Thread failed main thread check: Async chunk retrieval` whenever the cache refill task (Global Region Scheduler thread) tries to load a chunk that belongs to another region.

## Stack traces fixed

**teleportAsync:**
```
java.lang.UnsupportedOperationException: Must use teleportAsync while in region threading
    at org.bukkit.craftbukkit.entity.CraftPlayer.teleport0(CraftPlayer.java:1347)
    at justRTP.../AsyncTeleportSync.teleportAsync(AsyncTeleportSync.java:13)
    at justRTP.../PaperLib.teleportAsync(PaperLib.java:83)
    at eu.kotori.justRTP.handlers.RTPService.teleportPlayer(RTPService.java:185)
```

**getChunkAtAsync (cache refill task):**
```
java.lang.IllegalStateException: Thread failed main thread check: Async chunk retrieval,
context=[thread=Folia Region Scheduler Thread #0,...region={null}], world=minecraft:overworld
    at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:89)
    at org.bukkit.craftbukkit.CraftWorld.getChunkAt(CraftWorld.java:381)
    at justRTP.../AsyncChunksSync.getChunkAtAsync(AsyncChunksSync.java:16)
    at justRTP.../PaperLib.getChunkAtAsync(PaperLib.java:141)
    at eu.kotori.justRTP.handlers.RTPService.findLocationRecursive(RTPService.java:409)
    at eu.kotori.justRTP.managers.LocationCacheManager.fillQueueWorker(LocationCacheManager.java:231)
```

## Files changed
- `src/main/java/eu/kotori/justRTP/handlers/RTPService.java` — teleport + 3 chunk-load sites
- `src/main/java/eu/kotori/justRTP/handlers/PlayerListener.java` — cross-server teleport + chunk preload
- `src/main/java/eu/kotori/justRTP/utils/SafetyValidator.java` — async safety check
- `src/main/java/eu/kotori/justRTP/managers/NearClaimRTPManager.java` — near-claim chunk load
- `src/main/java/eu/kotori/justRTP/managers/PacketHologramManager.java` — hologram chunk load
- `src/main/java/eu/kotori/justRTP/managers/RTPZoneManager.java` — zone Y-finder chunk load

## Test plan
- [x] `mvn clean package` builds cleanly (verified locally)
- [x] On a Paper server, `/rtp` and RTP zones still work without behavior change
- [x] On a Folia / CanvasMC 26.1.2 server, `/rtp` teleports successfully without `UnsupportedOperationException`
- [x] On Folia/CanvasMC, location cache refill runs without `Thread failed main thread check` errors
- [ ] Cross-server RTP arrival teleport on Folia/CanvasMC works

🤖 Generated with [Claude Code](https://claude.com/claude-code)